### PR TITLE
Fix: Renamed installing-firmware.html

### DIFF
--- a/src/ConfigHandler.cpp
+++ b/src/ConfigHandler.cpp
@@ -324,7 +324,7 @@ namespace config{
         // config-firmware.html
         downloadFile("https://raw.githubusercontent.com/smartinizer/base-firmware-lib/main/data/config-firmware.html", "/config-firmware.html", false);
         // installing-firmware.html
-        downloadFile("https://raw.githubusercontent.com/smartinizer/base-firmware-lib/main/data/installing-firmware.html", "/config-firmware.html", false);
+        downloadFile("https://raw.githubusercontent.com/smartinizer/base-firmware-lib/main/data/installing-firmware.html", "/installing-firmware.html", false);
         // stype.css
         downloadFile("https://raw.githubusercontent.com/smartinizer/base-firmware-lib/main/data/style.css", "/style.css", false);
         // wifi.html


### PR DESCRIPTION
The file installing-firmware.html had the wrong name after downloading it, so the Webserver threw a 404 Error.
I fixed it by setting the right filename during the download.