### PR TITLE
fix(ConfigHandler): Wrong method call during flash erase

### DIFF
--- a/src/ConfigHandler.h
+++ b/src/ConfigHandler.h
@@ -7,6 +7,7 @@
 #include <HTTPClient.h>
 
 namespace config{
+    String readFile(String fileName);
     void writeWifiCredentials(String ssid, String pw);
     void writeUpdateConfig(String firmware_url);
     void deleteWifiCredentials();
@@ -16,7 +17,7 @@ namespace config{
     void deleteUpdateConfig();
     void downloadFirmwareList(String url);
     String getFirmwareList();
-    String getFirmwareConfig(String url);
+    String getFirmwareConfigSchema(String url);
     void writeFirmwareConfig(String firmwareConfig);
     String getConfigByKey(String key);
     void downloadStaticFiles();

--- a/src/WebBuilder.cpp
+++ b/src/WebBuilder.cpp
@@ -59,7 +59,7 @@ namespace webbuilder{
         }
         
         Serial.println("Firmware Config URL: " + configUrl);
-        String configJson = config::getFirmwareConfig(configUrl);
+        String configJson = config::getFirmwareConfigSchema(configUrl);
         String pageHTML = file.readString();
         pageHTML.replace("$CONFIG", configJson);
         file.close();


### PR DESCRIPTION
In the Method cleanFlashExceptFirmwareAndWifiConf() the wrong method was called.
Because the correct method did not exists I created it and refactored a bit.